### PR TITLE
fix: update solidity version to ^0.8.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "dapptools-template",
-  "version": "1.0.0",
+  "name": "@fei-protocol/erc4626",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dapptools-template",
-      "version": "1.0.0",
+      "name": "@fei-protocol/erc4626",
+      "version": "0.0.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "prettier": "^2.3.1",

--- a/src/ERC4626Router.sol
+++ b/src/ERC4626Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import "./ERC4626RouterBase.sol";
 

--- a/src/ERC4626RouterBase.sol
+++ b/src/ERC4626RouterBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {IERC4626, IERC4626RouterBase, ERC20} from "./interfaces/IERC4626RouterBase.sol";
 import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
 

--- a/src/interfaces/IERC4626Router.sol
+++ b/src/interfaces/IERC4626Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import "./IERC4626.sol";
 

--- a/src/interfaces/IERC4626RouterBase.sol
+++ b/src/interfaces/IERC4626RouterBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import "./IERC4626.sol";
 

--- a/src/test/ERC4626Router.t.sol
+++ b/src/test/ERC4626Router.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {ERC20, MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 import {MockERC4626} from "solmate/test/utils/mocks/MockERC4626.sol";
@@ -14,7 +14,6 @@ interface Assume {
 }
 
 contract ERC4626Test is DSTestPlus {
-
     MockERC20 underlying;
     IERC4626 vault;
     IERC4626 toVault;
@@ -22,12 +21,11 @@ contract ERC4626Test is DSTestPlus {
     IWETH9 weth;
     IERC4626 wethVault;
 
-    bytes32 public PERMIT_TYPEHASH = keccak256(
-                                "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
-                            );
+    bytes32 public PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
     receive() external payable {}
-    
+
     function setUp() public {
         underlying = new MockERC20("Mock Token", "TKN", 18);
 
@@ -48,7 +46,7 @@ contract ERC4626Test is DSTestPlus {
         underlying.approve(address(router), amount);
 
         router.approve(underlying, address(vault), amount);
-    
+
         router.pullToken(underlying, amount, address(router));
 
         router.mint(IERC4626(address(vault)), address(this), amount, amount);
@@ -64,7 +62,7 @@ contract ERC4626Test is DSTestPlus {
         underlying.approve(address(router), amount);
 
         router.approve(underlying, address(vault), amount);
-    
+
         router.pullToken(underlying, amount, address(router));
 
         router.deposit(IERC4626(address(vault)), address(this), amount, amount);
@@ -80,13 +78,13 @@ contract ERC4626Test is DSTestPlus {
         underlying.approve(address(router), amount);
 
         router.approve(underlying, address(vault), amount);
-    
+
         router.depositMax(IERC4626(address(vault)), address(this), amount);
 
         require(vault.balanceOf(address(this)) == amount);
         require(underlying.balanceOf(address(this)) == 0);
     }
-    
+
     function testDepositToVault(uint256 amount) public {
         Assume(address(hevm)).assume(amount != 0);
         underlying.mint(address(this), amount);
@@ -195,7 +193,7 @@ contract ERC4626Test is DSTestPlus {
         Assume(address(hevm)).assume(amount != 0);
         underlying.mint(address(this), amount);
 
-        underlying.approve(address(router), type(uint).max);
+        underlying.approve(address(router), type(uint256).max);
 
         router.approve(underlying, address(vault), amount);
         router.approve(underlying, address(toVault), amount);
@@ -205,7 +203,7 @@ contract ERC4626Test is DSTestPlus {
         require(vault.balanceOf(address(this)) == amount);
         require(underlying.balanceOf(address(this)) == 0);
 
-        vault.approve(address(router), type(uint).max);
+        vault.approve(address(router), type(uint256).max);
 
         router.withdrawToDeposit(vault, toVault, address(this), amount, amount, amount);
 
@@ -217,8 +215,8 @@ contract ERC4626Test is DSTestPlus {
     function testWithdrawToBelowMinOutReverts(uint128 amount) public {
         Assume(address(hevm)).assume(amount != 0 && amount != type(uint128).max);
         underlying.mint(address(this), amount);
-        
-        underlying.approve(address(router), type(uint).max);
+
+        underlying.approve(address(router), type(uint256).max);
 
         router.approve(underlying, address(vault), amount);
         router.approve(underlying, address(toVault), amount);
@@ -228,7 +226,7 @@ contract ERC4626Test is DSTestPlus {
         require(vault.balanceOf(address(this)) == amount);
         require(underlying.balanceOf(address(this)) == 0);
 
-        vault.approve(address(router), type(uint).max);
+        vault.approve(address(router), type(uint256).max);
 
         hevm.expectRevert(abi.encodeWithSignature("MinSharesError()"));
         router.withdrawToDeposit(vault, toVault, address(this), amount, amount, amount + 1);
@@ -238,7 +236,7 @@ contract ERC4626Test is DSTestPlus {
         Assume(address(hevm)).assume(amount != 0);
         underlying.mint(address(this), amount);
 
-        underlying.approve(address(router), type(uint).max);
+        underlying.approve(address(router), type(uint256).max);
 
         router.approve(underlying, address(vault), amount);
         router.approve(underlying, address(toVault), amount);
@@ -248,7 +246,7 @@ contract ERC4626Test is DSTestPlus {
         require(vault.balanceOf(address(this)) == amount);
         require(underlying.balanceOf(address(this)) == 0);
 
-        vault.approve(address(router), type(uint).max);
+        vault.approve(address(router), type(uint256).max);
 
         router.redeemToDeposit(vault, toVault, address(this), amount, amount);
 
@@ -261,7 +259,7 @@ contract ERC4626Test is DSTestPlus {
         Assume(address(hevm)).assume(amount != 0 && amount != type(uint128).max);
         underlying.mint(address(this), amount);
 
-        underlying.approve(address(router), type(uint).max);
+        underlying.approve(address(router), type(uint256).max);
 
         router.approve(underlying, address(vault), amount);
         router.approve(underlying, address(toVault), amount);
@@ -271,7 +269,7 @@ contract ERC4626Test is DSTestPlus {
         require(vault.balanceOf(address(this)) == amount);
         require(underlying.balanceOf(address(this)) == 0);
 
-        vault.approve(address(router), type(uint).max);
+        vault.approve(address(router), type(uint256).max);
 
         hevm.expectRevert(abi.encodeWithSignature("MinSharesError()"));
         router.redeemToDeposit(vault, toVault, address(this), amount, amount + 1);
@@ -297,7 +295,7 @@ contract ERC4626Test is DSTestPlus {
     function testWithdrawWithPermit(uint128 amount) public {
         Assume(address(hevm)).assume(amount != 0);
         underlying.mint(address(this), amount);
-        
+
         uint256 privateKey = 0xBEEF;
         address owner = hevm.addr(privateKey);
 
@@ -482,7 +480,7 @@ contract ERC4626Test is DSTestPlus {
         underlying.mint(address(this), amount);
 
         underlying.approve(address(router), amount);
-        
+
         router.approve(underlying, address(vault), amount);
 
         router.depositToVault(IERC4626(address(vault)), address(this), amount, amount);
@@ -513,7 +511,7 @@ contract ERC4626Test is DSTestPlus {
         Assume(address(hevm)).assume(amount != 0 && amount < 100 ether);
         underlying.mint(address(this), amount);
 
-        uint balanceBefore = address(this).balance;
+        uint256 balanceBefore = address(this).balance;
 
         router.approve(weth, address(wethVault), amount);
 
@@ -526,7 +524,13 @@ contract ERC4626Test is DSTestPlus {
         wethVault.approve(address(router), amount);
 
         bytes[] memory withdrawData = new bytes[](2);
-        withdrawData[0] = abi.encodeWithSelector(ERC4626RouterBase.withdraw.selector, wethVault, address(router), amount, amount);
+        withdrawData[0] = abi.encodeWithSelector(
+            ERC4626RouterBase.withdraw.selector,
+            wethVault,
+            address(router),
+            amount,
+            amount
+        );
         withdrawData[1] = abi.encodeWithSelector(PeripheryPayments.unwrapWETH9.selector, amount, address(this));
 
         router.multicall(withdrawData);

--- a/src/test/mocks/MockERC4626.sol
+++ b/src/test/mocks/MockERC4626.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {ERC4626} from "solmate/mixins/ERC4626.sol";
 
 contract MockERC4626 is ERC4626 {
-
     constructor(ERC20 underlying) ERC4626(underlying, "MockVault", "MV") {}
 
     function totalAssets() public view override returns (uint256) {
-      return asset.balanceOf(address(this));
+        return asset.balanceOf(address(this));
     }
 }

--- a/src/test/xERC4626.t.sol
+++ b/src/test/xERC4626.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
@@ -19,7 +19,7 @@ contract xERC4626Test is DSTestPlus {
         uint256 combined = uint256(seed) + uint256(reward);
 
         unchecked {
-            hevm.assume(seed != 0 && reward !=0 && combined < type(uint128).max);
+            hevm.assume(seed != 0 && reward != 0 && combined < type(uint128).max);
         }
 
         token.mint(address(this), combined);
@@ -37,27 +37,27 @@ contract xERC4626Test is DSTestPlus {
 
         xToken.syncRewards();
         // after sync, everything same except lastRewardAmount
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == seed);
         require(xToken.convertToAssets(seed) == seed); // 1:1 still
 
         // // accrue half the rewards
         hevm.warp(500);
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == uint256(seed) + (reward / 2));
         require(xToken.convertToAssets(seed) == uint256(seed) + (reward / 2)); // half rewards added
         require(xToken.convertToShares(uint256(seed) + (reward / 2)) == seed); // half rewards added
 
         // // accrue remaining rewards
         hevm.warp(1000);
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == combined);
         assertEq(xToken.convertToAssets(seed), combined); // all rewards added
         assertEq(xToken.convertToShares(combined), seed);
 
         // accrue all and warp ahead 1 cycle
         hevm.warp(2000);
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == combined);
         assertEq(xToken.convertToAssets(seed), combined); // all rewards added
         assertEq(xToken.convertToShares(combined), seed);
@@ -68,7 +68,7 @@ contract xERC4626Test is DSTestPlus {
         uint256 combined = uint256(seed) + uint256(reward);
 
         unchecked {
-            hevm.assume(seed != 0 && reward !=0 && combined < type(uint128).max);
+            hevm.assume(seed != 0 && reward != 0 && combined < type(uint128).max);
         }
 
         token.mint(address(this), combined);
@@ -93,27 +93,27 @@ contract xERC4626Test is DSTestPlus {
 
         // accrue half the rewards
         hevm.warp(750);
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == uint256(seed) + (reward / 2));
         require(xToken.convertToAssets(seed) == uint256(seed) + (reward / 2)); // half rewards added
 
         // accrue remaining rewards
         hevm.warp(1000);
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == combined);
         assertEq(xToken.convertToAssets(seed), combined); // all rewards added
         assertEq(xToken.convertToShares(combined), seed);
 
         // accrue all and warp ahead 1 cycle
         hevm.warp(2000);
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == combined);
         assertEq(xToken.convertToAssets(seed), combined); // all rewards added
         assertEq(xToken.convertToShares(combined), seed);
     }
 
     function testTotalAssetsAfterDeposit(uint128 deposit1, uint128 deposit2) public {
-        hevm.assume(deposit1 != 0 && deposit2 !=0);
+        hevm.assume(deposit1 != 0 && deposit2 != 0);
 
         uint256 combined = uint256(deposit1) + uint256(deposit2);
         token.mint(address(this), combined);
@@ -126,9 +126,8 @@ contract xERC4626Test is DSTestPlus {
     }
 
     function testTotalAssetsAfterWithdraw(uint128 deposit, uint128 withdraw) public {
-        
         hevm.assume(deposit != 0 && withdraw != 0 && withdraw <= deposit);
-        
+
         token.mint(address(this), deposit);
         token.approve(address(xToken), deposit);
 
@@ -139,11 +138,15 @@ contract xERC4626Test is DSTestPlus {
         require(xToken.totalAssets() == deposit - withdraw);
     }
 
-    function testSyncRewardsFailsDuringCycle(uint128 seed, uint128 reward, uint256 warp) public {
+    function testSyncRewardsFailsDuringCycle(
+        uint128 seed,
+        uint128 reward,
+        uint256 warp
+    ) public {
         uint256 combined = uint256(seed) + uint256(reward);
 
         unchecked {
-            hevm.assume(seed != 0 && reward !=0 && combined < type(uint128).max);
+            hevm.assume(seed != 0 && reward != 0 && combined < type(uint128).max);
         }
 
         token.mint(address(this), seed);
@@ -163,7 +166,7 @@ contract xERC4626Test is DSTestPlus {
         uint256 combined = uint256(seed) + uint256(reward);
 
         unchecked {
-            hevm.assume(seed != 0 && reward !=0 && combined < type(uint128).max);
+            hevm.assume(seed != 0 && reward != 0 && combined < type(uint128).max);
         }
 
         token.mint(address(this), seed);
@@ -175,9 +178,9 @@ contract xERC4626Test is DSTestPlus {
 
         // sync with no new rewards
         xToken.syncRewards();
-        require(xToken.lastRewardAmount() == 0);  
-        require(xToken.lastSync() == 100);  
-        require(xToken.rewardsCycleEnd() == 1000);  
+        require(xToken.lastRewardAmount() == 0);
+        require(xToken.lastSync() == 100);
+        require(xToken.rewardsCycleEnd() == 1000);
         require(xToken.totalAssets() == seed);
         require(xToken.convertToShares(seed) == seed);
 
@@ -186,24 +189,28 @@ contract xERC4626Test is DSTestPlus {
         token.mint(address(xToken), reward); // seed new rewards
 
         xToken.syncRewards();
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == seed);
         require(xToken.convertToShares(seed) == seed);
 
         hevm.warp(2000);
 
-        require(xToken.lastRewardAmount() == reward);  
+        require(xToken.lastRewardAmount() == reward);
         require(xToken.totalAssets() == combined);
         require(xToken.convertToAssets(seed) == combined);
         assertEq(xToken.convertToShares(combined), seed);
     }
 
-    function testSyncRewardsAfterFullCycle(uint128 seed, uint128 reward, uint128 reward2) public {
+    function testSyncRewardsAfterFullCycle(
+        uint128 seed,
+        uint128 reward,
+        uint128 reward2
+    ) public {
         uint256 combined1 = uint256(seed) + uint256(reward);
         uint256 combined2 = uint256(seed) + uint256(reward) + reward2;
 
         unchecked {
-            hevm.assume(seed != 0 && reward !=0 && reward2 != 0 && combined2 < type(uint128).max);
+            hevm.assume(seed != 0 && reward != 0 && reward2 != 0 && combined2 < type(uint128).max);
         }
 
         token.mint(address(this), seed);
@@ -216,9 +223,9 @@ contract xERC4626Test is DSTestPlus {
         token.mint(address(xToken), reward); // seed new rewards
         // sync with new rewards
         xToken.syncRewards();
-        require(xToken.lastRewardAmount() == reward);  
-        require(xToken.lastSync() == 100);  
-        require(xToken.rewardsCycleEnd() == 1000);  
+        require(xToken.lastRewardAmount() == reward);
+        require(xToken.lastSync() == 100);
+        require(xToken.rewardsCycleEnd() == 1000);
         require(xToken.totalAssets() == seed);
         require(xToken.convertToShares(seed) == seed); // 1:1 still
 
@@ -227,13 +234,13 @@ contract xERC4626Test is DSTestPlus {
         token.mint(address(xToken), reward2); // seed new rewards
 
         xToken.syncRewards();
-        require(xToken.lastRewardAmount() == reward2);  
+        require(xToken.lastRewardAmount() == reward2);
         require(xToken.totalAssets() == combined1);
         require(xToken.convertToAssets(seed) == combined1);
 
         hevm.warp(2000);
 
-        require(xToken.lastRewardAmount() == reward2);  
+        require(xToken.lastRewardAmount() == reward2);
         require(xToken.totalAssets() == combined2);
         require(xToken.convertToAssets(seed) == combined2);
     }


### PR DESCRIPTION
This PR updates the solidity version from stable 0.8.10 to ^0.8.10 allowing the ERC4626 router to be used in the collectif protocol